### PR TITLE
Improve Docker image size and utility

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -1,35 +1,34 @@
 # Try to maintain user-servicable parts up front
-ARG OTP_VERSION=27.3.3
-ARG DEBIAN_VERSION=bookworm-20250407-slim
+# ARG OTP_VERSION=27.3.3
+ARG ALPINE_VERSION=3.21.3
 
-ARG BUILDER_IMAGE="hexpm/erlang:${OTP_VERSION}-debian-${DEBIAN_VERSION}"
-ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
+ARG BUILDER_IMAGE="erlang:alpine"
+ARG RUNNER_IMAGE="alpine:${ALPINE_VERSION}"
 
 FROM ${BUILDER_IMAGE} AS builder
 
-RUN apt-get update -y && apt-get install -y build-essential git rebar3 \
-    && apt-get clean && rm -f /var/lib/apt/lists/*_*
+RUN apk update && apk add git  && \
+	rm -rf /var/cache/apk/*
 
 WORKDIR /builder
 
+COPY .git .git/
 COPY src src/
 COPY include include/
+COPY priv priv/
 COPY rebar.config .
-RUN rebar3 compile
 RUN rebar3 as fly_er release
+
 
 FROM ${RUNNER_IMAGE}
 
 WORKDIR "/erlang-red"
-RUN apt-get update -y && apt-get install -y openssl \
-    && apt-get clean && rm -f /var/lib/apt/lists/*_*
+RUN apk update && apk add libncursesw libstdc++ openssl && \
+	rm -rf /var/cache/apk/*
 RUN chown nobody /
 
 # Only copy the final release from the build stage
 COPY --from=builder --chown=nobody:root /builder/_build/fly_er/rel/fly_er ./
-# The below should happen automatically
-# This is way too specific and fragile.
-COPY priv ./lib/erlang_red-0.1.0/priv/
 
 USER nobody
 EXPOSE 8080


### PR DESCRIPTION
- Add `.git` directory to builder
  - An unfortunate amount of copying to the builder for the minimal benefit of a version tag
  - Should removed when a `VERSION` file or similar becomes available
- Add `/priv` to builder
  - `rebar3` now copies into release
  - Allows removal of fragile hand-copy
- Move from debian to alpine for smaller image sizes
  - Usually also means faster builds with fewer dependencies

NB: This has been smoke-tested on the `ered` deployment