### PR TITLE
Basic auth

### DIFF
--- a/fly-er.sh
+++ b/fly-er.sh
@@ -23,8 +23,30 @@ fly auth whoami
 # Ask them for an appname.  We cannot easily determine if it
 # fits fly naming rules (and is available).. so just take any string
 read -p "Provide a fly app name: " APPNAME
+
+read -p "Use basic auth to protect this instance? [yN] " DO_BASIC
+
+if [[ "Y" == ${DO_BASIC}  || "y" == ${DO_BASIC} ]]; then
+	# Gather them now, but it needs to be launched before
+	# they can be applied.
+	# It's only a line below, but it's a relatively long
+	# time in the flow of a run.
+	read -p "Site user: " ERED_USER
+	read -p "Site pass: " ERED_PASS
+fi
+
 echo "=> Attempting to launch ${APPNAME}..."
 fly launch --name="${APPNAME}" --ha="false" --dockerfile "${FLY_DOCKERFILE}"
+
+if [[ "Y" == ${DO_BASIC}  || "y" == ${DO_BASIC} ]]; then
+	echo "==> Setting secrets for basic auth...";
+	# Fly secrets are put into environment variables when
+	# the application is started
+	echo "   ...user";
+	fly secrets set ERED_USER="${ERED_USER}"
+	echo "   ...password";
+	fly secrets set ERED_PASS="${ERED_PASS}"
+fi
 
 # Warn them that the config file might be sort of ephemeral
 # in its current location

--- a/src/http/ered_http_auth.erl
+++ b/src/http/ered_http_auth.erl
@@ -1,0 +1,58 @@
+-module(ered_http_auth).
+-behaviour(cowboy_middleware).
+
+-export([execute/2]).
+
+execute(Req, Env) ->
+    case
+        {
+            is_protected(Req),
+            os:getenv("ERED_USER"),
+            os:getenv("ERED_PASS"),
+            cowboy_req:parse_header(<<"authorization">>, Req)
+        }
+    of
+        % We cam skeddaddle if it's not a protected path
+        {false, _, _, _} ->
+            {ok, Req, Env};
+        % Both enviornment values should be set to enable Basic Auth
+        {_, false, _, _} ->
+            {ok, Req, Env};
+        {_, _, false, _} ->
+            {ok, Req, Env};
+        % They are set but the client didn't send auth request
+        {true, _, _, undefined} ->
+            say_no(Req);
+        {true, User, Pass, {basic, Buser, Bpass}} ->
+            case {string:equal(User, Buser), string:equal(Pass, Bpass)} of
+                % And, of course, we want them to match
+                {true, true} -> {ok, Req, Env};
+                % The credentials didn't match, be insistent
+                _ -> say_no(Req)
+            end
+    end.
+
+%% Convenience function to send the auth demand
+say_no(Req) ->
+    {stop,
+        cowboy_req:reply(401, #{<<"www-authenticate">> => <<"Basic realm=\"Erlang-RED\"">>}, Req)}.
+
+% Using the request object because we might want additional different logic later
+is_protected(#{path := Path}) ->
+    case Path of
+        %% A couple exact matches
+        <<"/flows.initial.json">> -> true;
+        <<"/settings.json">> -> true;
+        %% This covers a couple directories, actually
+        <<"/node", _/binary>> -> true;
+        %% We can reuse for the wrapper site
+        <<"/red/images/", _/binary>> -> false;
+        <<"/red/", _/binary>> -> true;
+        %% And just to prevent spidering around when its
+        %% obvious what paths might exist
+        <<"/plugins/", _/binary>> -> true;
+        <<"/vendor/", _/binary>> -> true;
+        <<"/settings/", _/binary>> -> true;
+        <<"/types/", _/binary>> -> true;
+        _ -> false
+    end.

--- a/src/servers/ered_webserver.erl
+++ b/src/servers/ered_webserver.erl
@@ -41,7 +41,7 @@ herd_up_the_cattle() ->
     {ok, _} = cowboy:start_clear(
         erlang_red_listener,
         [{port, 8080}],
-        #{env => #{dispatch => router()}}
+        #{env => #{dispatch => router()}, middlewares => [ered_http_auth, cowboy_router, cowboy_handler]}
     ).
 
 %%


### PR DESCRIPTION
This adds basic auth for all of the interesting parts via a `cowboy_middleware`.

This seems like the most sane way to get into the HTTP pipeline and not introduce a *lot* of custom code.