### PR TITLE
Use git tag for release versions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 ]}.
 
 {relx, [
-    {release, {fly_er, {git, short}}, [erlang_red, sasl, erlydtl]},
+    {release, {fly_er, git}, [erlang_red, sasl, erlydtl]},
 
     {dev_mode, false},
     {include_erts, true},


### PR DESCRIPTION
This is not quite as exact, but it is much more humane in terms of understanding which code is running.