### PR TITLE
Add some build tools to alpine builder

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -7,7 +7,8 @@ ARG RUNNER_IMAGE="alpine:${ALPINE_VERSION}"
 
 FROM ${BUILDER_IMAGE} AS builder
 
-RUN apk update && apk add git  && \
+RUN apk update && apk add alpine-sdk bash curl \
+                          cmake perl linux-headers && \
 	rm -rf /var/cache/apk/*
 
 WORKDIR /builder


### PR DESCRIPTION
New dependencies need help getting built.
This seems like a near minimal somewhat future-proof set of packages. At least as compared to adding them one by one due to failures.