### PR TITLE
Update Fly dockerfile for Elixir inclusion

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -1,14 +1,15 @@
 # Try to maintain user-servicable parts up front
-# ARG OTP_VERSION=27.3.3
+ARG ELIXIR_VERSION=1.18.3
+ARG OTP_VERSION=27.3.4
 ARG ALPINE_VERSION=3.21.3
 
-ARG BUILDER_IMAGE="erlang:alpine"
+ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-alpine-${ALPINE_VERSION}"
 ARG RUNNER_IMAGE="alpine:${ALPINE_VERSION}"
 
 FROM ${BUILDER_IMAGE} AS builder
 
-RUN apk update && apk add alpine-sdk bash curl \
-                          cmake perl linux-headers && \
+RUN apk update && \
+    apk add alpine-sdk bash curl cmake perl linux-headers rebar3 && \
 	rm -rf /var/cache/apk/*
 
 WORKDIR /builder


### PR DESCRIPTION
Dockerfile.fly changes:
- Move to `hexpm` alpine images with elixir and erlang
- Add now-missing `rebar3` package
- Improve formatting slightly with changes

We get elixir into the image even though it doesn't benefit the running application so much at this point. We want to be ready!

As things progress, I intend to work through some of the "cloud-local" impedence mismatch issues. I don't want to impede the progress with my nonsense just yet, though.

NB. I was planning to use `hexpm` alpine images when I was decreasing the image size.  I couldn't find them.  DockerHub "filters" are amazingly bad.