### PR TITLE
Update fly docker to fetch dependencies first

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -19,12 +19,9 @@ COPY src src/
 COPY include include/
 COPY priv priv/
 COPY rebar.config .
+COPY rebar.lock .
 
-## Repeating the building is necessary because dependency computation
-## only works on the second go. This is really weird since the same
-## code in the heroku dockerfile just works the first time. I don't
-## understand it but rinse & repeat works here ...
-RUN rebar3 as prod release -n erlang_red || true
+RUN rebar3 get-deps
 RUN rebar3 as prod release -n erlang_red
 
 


### PR DESCRIPTION
The Docker build agent output was very weird.  Luckily someone smarter than me gave some guidance.

This has been successfully deployed... now with passing Markdown tests:

![md-tests](https://github.com/user-attachments/assets/c18c456a-c888-4783-916c-253739bc1382)
