### PR TITLE
Sort loaded applications for status

### DIFF
--- a/src/routes/ered_http_release_status.erl
+++ b/src/routes/ered_http_release_status.erl
@@ -39,7 +39,7 @@ handle_get_response(Req, State) ->
             %% This should actually only be one for now
             %% But we'll take the first if we messed up
             [{Name, Vsn, Apps, RelStat} | _] ->
-                [{name, Name}, {version, Vsn}, {apps, Apps}, {status, RelStat}];
+                [{name, Name}, {version, Vsn}, {apps, lists:sort(Apps)}, {status, RelStat}];
             _ ->
                 []
         end,


### PR DESCRIPTION
My friend said it was hard for him to find the packages in which he was interested (mostly `erlang_red*`.  I was so excited that anyone was even looking at the site that I made this change.

In the long term, if this page stays as-is and the overhead of doing all of this dynamically becomes an issue, I'll work to build the structures at compile time.