### PR TITLE
Include system libs when release

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -58,6 +58,7 @@
 
     {dev_mode, false},
     {include_erts, true},
+    {system_libs, true},
     {include_src, false},
     {overlay, [
         {copy, "priv/*", "priv/"}


### PR DESCRIPTION
When cross compiling erlang-red and making a release, it is necessary to also enable the system_lib flag. That way OTP libs will be included into release package.

Without system_libs, I have a situation where ERTS is included with the correct files while OTP libs from host system is included, I expected the target files instead.

For more details [1].

1: https://www.rebar3.org/docs/deployment/releases/#with-erts-built-for-another-system