### PR TITLE
Remove overlay copy to priv

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -59,10 +59,7 @@
     {dev_mode, false},
     {include_erts, true},
     {system_libs, true},
-    {include_src, false},
-    {overlay, [
-        {copy, "priv/*", "priv/"}
-    ]}
+    {include_src, false}
 ]}.
 
 {plugins, [exerl]}.


### PR DESCRIPTION
This overlay ended up adding an extra copy of priv folder intro root release folder.