### PR TITLE
Dialyzer mends

### DIFF
--- a/src/nodes/ered_node_csv.erl
+++ b/src/nodes/ered_node_csv.erl
@@ -239,8 +239,13 @@ send_one_msg_per_row(NodeDef, Msg, [Row | MoreRows], ColNames, Idx, Len) ->
 create_columns_values(Row) ->
     list_to_binary(lists:join(",", Row)).
 
+-spec obtain_columns(AllRows, HdrIn) -> Result
+	      when AllRows :: [_|_],
+		   HdrIn   :: boolean() | <<>>,
+		   Result  :: {_, [_]}.
+
 obtain_columns([FirstRow | HeadlessData], true) ->
-    {[F || F <- FirstRow], HeadlessData};
+    {FirstRow, HeadlessData};
 obtain_columns([FirstRow | _RestData] = AllRows, _HdrIn) ->
     {
         [

--- a/src/nodes/ered_node_function.erl
+++ b/src/nodes/ered_node_function.erl
@@ -276,13 +276,8 @@ clear_status_after_one_sec(WsName, NodeDef) ->
 %% ErrorLists and WarnLists aren't JSON compatible therefore they need to be
 %% massaged into form.
 %% See https://www.erlang.org/doc/apps/compiler/compile.html for details.
-compiler_list_to_json_list([]) ->
-    [];
 compiler_list_to_json_list({_Line, _Module, _Desc} = Eroro) ->
     errorinfo_tuple_to_list(Eroro);
-compiler_list_to_json_list([ErrorInfo | Lst]) ->
-    [errorinfo_tuple_to_list(ErrorInfo) | compiler_list_to_json_list(Lst)].
-
 errorinfo_tuple_to_list({Line, Module, Desc}) ->
     [
         % subtract 2 because there is a wrapper function around the code.

--- a/src/nodes/ered_node_function.erl
+++ b/src/nodes/ered_node_function.erl
@@ -277,7 +277,7 @@ clear_status_after_one_sec(WsName, NodeDef) ->
 %% massaged into form.
 %% See https://www.erlang.org/doc/apps/compiler/compile.html for details.
 compiler_list_to_json_list({_Line, _Module, _Desc} = Eroro) ->
-    errorinfo_tuple_to_list(Eroro);
+    errorinfo_tuple_to_list(Eroro).
 errorinfo_tuple_to_list({Line, Module, Desc}) ->
     [
         % subtract 2 because there is a wrapper function around the code.

--- a/src/nodes/ered_node_switch.erl
+++ b/src/nodes/ered_node_switch.erl
@@ -208,11 +208,9 @@ does_regex_match(
                 [dollar_endonly, dotall, extended] ++ get_caseless(IgnoreCase)
             ),
             case re:run(MsgVal, RegExp) of
-                match ->
-                    true;
                 {match, _} ->
                     true;
-                _ ->
+                nomatch ->
                     false
             end;
         {error, ErrMsg} ->


### PR DESCRIPTION
This pr fixes several minor issues that occurred in several node implementations:

- `ered_node_csv` remove faulty list comprehension, add function spec for `obtain_columns`
- `ered_node_function` remove unused clauses in function `compiler_list_to_json_list`
- `ered_node_switch` remove unused branch in case clause