### PR TITLE
fix sys.config.src contents

### DIFF
--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -1,1 +1,1 @@
-["priv/sys.config"].
+[].

--- a/dockerfiles/Dockerfile.fly
+++ b/dockerfiles/Dockerfile.fly
@@ -44,7 +44,7 @@ COPY --from=builder --chown=nobody:root /builder/_build/prod/rel/erlang_red ./
 ENV SHELL=/bin/sh
 ## vm.args.src
 ENV NODE_NAME=nonode@example.com
-RUN echo "[{erlang_red, [{flow_store, \"/tmp\"}]}]." >> sys.config
+RUN echo "[{erlang_red, [{flow_store, \"/tmp\"}]}]." > sys.config
 
 USER nobody
 

--- a/dockerfiles/Dockerfile.hub
+++ b/dockerfiles/Dockerfile.hub
@@ -69,7 +69,7 @@ ENV LANG=C.UTF-8
 ENV ELIXIR_ERL_OPTIONS="+fnu"
 
 ENV NODE_NAME=erlang-red@spreads-the.love
-RUN echo "[{erlang_red, [{flow_store, \"/tmp\"}]}]." >> sys.config
+RUN echo "[{erlang_red, [{flow_store, \"/tmp\"}]}]." > sys.config
 
 ## needed for nobody
 USER nobody


### PR DESCRIPTION
The sys.config.src is not valid. It should be an empty list or a list of properlist with application config. Let it as empty list because the default config works.

Also for dockerfile (fly and hub) write a config to sys.config (not appending it).